### PR TITLE
Add PMCA-HDMICam

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -116,3 +116,14 @@ release:
   type: github
   user: schnatterer
   repo: pmcaFilesystemServer
+
+---
+package: com.github.dired.pmcahdmicam
+name: HDMI Camera
+author: dired
+desc: Provides clean HDMI Output
+homepage: https://github.com/dired/PMCA-HDMICam
+release:
+  type: github
+  user: dired
+  repo: PMCA-HDMICam


### PR DESCRIPTION
I know it's basically PMCADemo without the bar at the top inside the "Camera".
But people have been requesting this a lot, and me (or others) could make more functions of the CameraEx-library available through the otherwise unused buttons. I will do just that if I need it for my projects. 
If you consider adding the app, I would, after hearing from you, clean away the redundant things from PMCADemo except for the Camera and the settings. If you think it's a bad idea I would not go into such efforts.

Thank you for the existence of this platform.
Best, dired