### PR TITLE
Added gps donwloader app

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -116,3 +116,15 @@ release:
   type: github
   user: schnatterer
   repo: pmcaFilesystemServer
+
+---
+package: org.mg.gpsdownloader
+name: GPS Downloader
+author: grueni75
+desc: Downloads the GPS assist data for faster locks
+homepage: https://github.com/grueni75/GPSDownloader
+release:
+  type: github
+  user: grueni75
+  repo: GPSDownloader
+


### PR DESCRIPTION
For cameras with GPS, the assis data needs to be downloaded manually to the sdcard. This app downloads the data directly to the sdcard, preventing the extra step with a PC. 